### PR TITLE
minor build fixes

### DIFF
--- a/examples/xtrx_fft/CMakeLists.txt
+++ b/examples/xtrx_fft/CMakeLists.txt
@@ -26,5 +26,6 @@ set(mainwindow_SRCS
 
 include_directories(${LIBXTRX_INCLUDE_DIRS})
 
-add_executable(mainwindow ${mainwindow_SRCS})
-target_link_libraries(mainwindow Qt5::Widgets Qt5::PrintSupport ${QCustomPlot_LIBRARIES} ${LIBXTRX_LIBRARIES})
+add_executable(xtrx_fft ${mainwindow_SRCS})
+target_link_libraries(xtrx_fft Qt5::Widgets Qt5::PrintSupport ${QCustomPlot_LIBRARIES} ${LIBXTRX_LIBRARIES})
+install(TARGETS xtrx_fft DESTINATION ${XTRX_UTILS_DIR})

--- a/xtrx_fe_octorx0.c
+++ b/xtrx_fe_octorx0.c
@@ -7,7 +7,7 @@
 #include <assert.h>
 #include <stdarg.h>
 
-#include "../liblms7002m/liblms7002m.h"
+#include <liblms7002m.h>
 
 #include "xtrx_api.h"
 #include "xtrx_fe_nlms7.h"


### PR DESCRIPTION
When you trying to build using own directory disposition you'll got ENOENT. Fixed with including from stardard include directories.

Also fixed example binary name and added install target.