### PR TITLE
Fix compilation due to xtrx_api.h not being found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ find_package(libxtrxll REQUIRED)
 
 include_directories(${LIBXTRXDSP_INCLUDE_DIRS})
 include_directories(${LIBXTRXLL_INCLUDE_DIRS})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 
 if(LMS_FE_OLD)


### PR DESCRIPTION
Without that fix we have:
  [ 40%] Building C object CMakeFiles/xtrx.dir/xtrx_fe_octocal0.c.o
  In file included from [...]/libxtrx/xtrx_fe_octocal0.c:15:
  [...]/libxtrx/octo/xtrx_octo_api.h:4:10: fatal error: xtrx_api.h: No such file or directory
   #include <xtrx_api.h>
            ^~~~~~~~~~~~
  compilation terminated.
  make[2]: *** [CMakeFiles/xtrx.dir/build.make:128: CMakeFiles/xtrx.dir/xtrx_fe_octocal0.c.o] Error 1

Signed-off-by: Denis 'GNUtoo' Carikli <GNUtoo@cyberdimension.org>