### PR TITLE
Fix SoapySDR getgain and division by zero issue

### DIFF
--- a/soapy/SoapyXTRX.cpp
+++ b/soapy/SoapyXTRX.cpp
@@ -362,7 +362,8 @@ SoapySDR::Range SoapyXTRX::getGainRange(const int direction, const size_t channe
 	if (direction == SOAPY_SDR_RX)
 	{
 		//make it so gain of 0.0 sets PGA at its mid-range
-		return SoapySDR::Range(-12.0, 19.0+12.0+30.0);
+		//return SoapySDR::Range(-12.0, 19.0+12.0+30.0); //-12.0 causes bad calculation of SoapySDR::getGain
+		return SoapySDR::Range(0.0, 19.0+12.0+30.0);
 	}
 	return SoapySDR::Device::getGainRange(direction, channel);
 }

--- a/xtrx.c
+++ b/xtrx.c
@@ -352,6 +352,15 @@ int xtrx_open(const char* device, unsigned flags, struct xtrx_dev** outdev)
 	}
 
 	*outdev = dev;
+
+	/* We need to set a samplerate, otherwise if we set frequency first, it will crash due to a divide of fref by zero.*/
+    unsigned int MIN_TX_RATE = 2100000;
+    double master_clock;
+    double _actual_rx_rate;
+    double _actual_tx_rate;
+    int ret = xtrx_set_samplerate(dev, 0, MIN_TX_RATE, MIN_TX_RATE,
+                                  0, //XTRX_SAMPLERATE_FORCE_UPDATE,
+                                  &master_clock, &_actual_rx_rate, &_actual_tx_rate);
 	return 0;
 
 


### PR DESCRIPTION
 Fix crash on SoapySDR usage

This fix addresses the issue if frequency is set before samplerate, resulting in fref to be zero, thus the application will crash
due to division by zero in liblms7002m.c, function lms7_pll_calc.

GetGain fix addresses issue #66 at xtrx-sdr/images