### PR TITLE
Fix getgain incorrect calculation

### DIFF
--- a/soapy/SoapyXTRX.cpp
+++ b/soapy/SoapyXTRX.cpp
@@ -362,7 +362,8 @@ SoapySDR::Range SoapyXTRX::getGainRange(const int direction, const size_t channe
 	if (direction == SOAPY_SDR_RX)
 	{
 		//make it so gain of 0.0 sets PGA at its mid-range
-		return SoapySDR::Range(-12.0, 19.0+12.0+30.0);
+		//return SoapySDR::Range(-12.0, 19.0+12.0+30.0); //-12.0 causes bad calculation of SoapySDR::getGain
+		return SoapySDR::Range(0.0, 19.0+12.0+30.0);
 	}
 	return SoapySDR::Device::getGainRange(direction, channel);
 }


### PR DESCRIPTION
Fix for issue https://github.com/xtrx-sdr/images/issues/60. 

The Rx Gain is being calculated by adding all gains. Having a look at the implementation: https://github.com/pothosware/SoapySDR/blob/fe8dfd1879a8512aa305045ef1e6657a5a33f3b9/lib/Device.cpp#L313-L314

The issue seems to be this line :
https://github.com/xtrx-sdr/libxtrx/blob/4f1eb7b5f77c90bc8d0db2a17fe338372e3d4277/soapy/SoapyXTRX.cpp#L365

On setting the lna gain to 20 and all other gains to 0, the SoapySDR getgain function will return 30 instead.

The root cause is that the minimum gain from the getrange function is being substracted (here -12). As 18-(-12)=30, the negative value seems to cause the issue. Thus setting the minimum at https://github.com/xtrx-sdr/libxtrx/blob/4f1eb7b5f77c90bc8d0db2a17fe338372e3d4277/soapy/SoapyXTRX.cpp#L365 to 0 instead of -12 does fix that issue.