### PR TITLE
Fix test_xtrx_soapy build issue

### DIFF
--- a/soapy/test_xtrx_soapy.c
+++ b/soapy/test_xtrx_soapy.c
@@ -67,8 +67,8 @@ int main(void)
 
     //setup a stream (complex floats)
     SoapySDRStream *rxStream;
-    if (SoapySDRDevice_setupStream(sdr, &rxStream, SOAPY_SDR_RX, SOAPY_SDR_CF32, NULL, 0, NULL) != 0)
-    {
+    rxStream = SoapySDRDevice_setupStream(sdr, SOAPY_SDR_RX, SOAPY_SDR_CF32, NULL, 0, NULL);
+    if ( rxStream == 0)    {
         printf("setupStream fail: %s\n", SoapySDRDevice_lastError());
     }
     SoapySDRDevice_activateStream(sdr, rxStream, 0, 0, 0); //start streaming


### PR DESCRIPTION
The Soapy setupstream function now passes back rxStream as the
return value rather than taking it as a parameter.  This PR
corrects the code to build correctly and addresses issue #23.