### PR TITLE
soapy: Fix RX stream activation by avoiding unintended runtime error.

### DIFF
--- a/soapy/SoapyXTRX.cpp
+++ b/soapy/SoapyXTRX.cpp
@@ -1191,7 +1191,8 @@ int SoapyXTRX::activateStream(
 		} else {
 			_tx_internal = 32768;
 		}
-	} else {
+	}
+	if ((stream != STREAM_RX) && (stream != STREAM_TX)) {
 		throw std::runtime_error("SoapyXTRX::activateStream() - incorrect stream");
 	}
 


### PR DESCRIPTION
The change introduced with 1c0ad68#r38372515 causes requests for RX streams
to fail with an "incorrect stream" runtime error. This commit resolves
issue #27.