### PR TITLE
install binaries (TARGETS) in proper directory (bin)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,9 +54,9 @@ endif()
 
 add_definitions(-Wall -g)
 
+set(XTRX_RUNTIME_DIR      bin)
 set(XTRX_LIBRARY_DIR      lib${LIB_SUFFIX})
 set(XTRX_INCLUDE_DIR      include)
-set(XTRX_UTILS_DIR        ${XTRX_LIBRARY_DIR}/xtrx)
 
 CONFIGURE_FILE(
 	${CMAKE_CURRENT_SOURCE_DIR}/libxtrx.pc.in
@@ -113,8 +113,8 @@ endif()
 ########################################################################
 # install libraries
 ########################################################################
-install(TARGETS xtrx DESTINATION ${XTRX_LIBRARY_DIR})
-install(TARGETS test_xtrx DESTINATION ${XTRX_UTILS_DIR})
+install(TARGETS xtrx DESTINATION ${XTRX_RUNTIME_DIR})
+install(TARGETS test_xtrx DESTINATION ${XTRX_RUNTIME_DIR})
 
 ########################################################################
 # install headers

--- a/examples/xtrx_fft/CMakeLists.txt
+++ b/examples/xtrx_fft/CMakeLists.txt
@@ -28,4 +28,4 @@ include_directories(${LIBXTRX_INCLUDE_DIRS})
 
 add_executable(xtrx_fft ${mainwindow_SRCS})
 target_link_libraries(xtrx_fft Qt5::Widgets Qt5::PrintSupport ${QCustomPlot_LIBRARIES} ${LIBXTRX_LIBRARIES})
-install(TARGETS xtrx_fft DESTINATION ${XTRX_UTILS_DIR})
+install(TARGETS xtrx_fft DESTINATION ${XTRX_RUNTIME_DIR})


### PR DESCRIPTION
with Linux system, binaries are usually installed in bin directory.